### PR TITLE
Fix examples 5 & 6

### DIFF
--- a/05_recordSingleImages/main.c
+++ b/05_recordSingleImages/main.c
@@ -17,11 +17,9 @@ int main(int argc, char* argv[])
     printf("To few Arguments! Please provide:\n");
     printf("user settings directory\n");
     printf("factory directory\n");
-    printf("name of recording directory\n");
+    printf("path of recording directory\n");
     printf("exposure time in ms\n");
     printf("number of images\n");
-    fflush(stdout);
-
     return -1;
   }
 
@@ -35,40 +33,36 @@ int main(int argc, char* argv[])
   int nrImages = atoi(nrImagesString);
 
   printf("Example 05 record single image\n");
-  printf("User Settings Dir: ");
+  printf("User Settings directory: ");
   printf(userSettingsDir);
-  printf("\nFactory Dir: ");
+  printf("\nFactory directory: ");
   printf(factoryDir);
-  printf("\nRecording Dir: ");
+  printf("\nRecording directory: ");
   printf(recDir);
   printf("\nExposure in ms: %d\n", exposure_ms);
-  printf("Number of Images: %d\n", nrImages);
-  fflush(stdout);
+  printf("Number of images: %d\n", nrImages);
 
   CUVIS_CALIB calib;
   CUVIS_ACQ_CONT acqCont;
   CUVIS_PROC_CONT procCont;
 
-  printf("loading user settings...\n");
-  fflush(stdout);
+  printf("load user settings...\n");
   CUVIS_CHECK(cuvis_init(userSettingsDir));
+  cuvis_set_log_level(loglevel_info);
 
   printf("load calibration...\n");
-  fflush(stdout);
   CUVIS_CHECK(cuvis_calib_create_from_path(factoryDir, &calib));
 
-  printf("loading processing context... \n");
-  fflush(stdout);
+  printf("initialize processing context...\n");
   CUVIS_CHECK(cuvis_proc_cont_create_from_calib(calib, &procCont));
 
-  printf("load acquisition context...\n");
-  fflush(stdout);
+  printf("initialize acquisition context...\n");
   CUVIS_CHECK(cuvis_acq_cont_create_from_calib(calib, &acqCont));
 
-  printf("prepare saving of measurements... \n");
-  fflush(stdout);
+  printf("initialize measurement exporter...\n");
   CUVIS_EXPORTER cube_exporter;
 
+  // Export settings: General processing of measurements
   CUVIS_EXPORT_GENERAL_SETTINGS general_settings = {
       "", //initializer list only takes const char*, leave empty and modify afterwards.
       "all",
@@ -81,21 +75,27 @@ int main(int argc, char* argv[])
 
   strcpy(general_settings.export_dir, recDir);
 
+  // Cube exporter specific settings
   CUVIS_EXPORT_CUBE_SETTINGS cube_settings;
   cube_settings.allow_fragmentation = 0;
   cube_settings.allow_overwrite = 1;
   cube_settings.allow_session_file = 1;
+  cube_settings.allow_info_file = 1;
+  cube_settings.hard_limit = 4;
+  cube_settings.soft_limit = 2;
 
+  // Settings for worker (processing pipeline)
   CUVIS_WORKER_SETTINGS worker_settings;
   worker_settings.keep_out_of_sequence = 1;
-  worker_settings.poll_interval = 0; //in ms
-  worker_settings.worker_count = 0;
-  worker_settings.worker_queue_hard_limit = 2;
-  worker_settings.worker_queue_soft_limit = 1;
+  worker_settings.poll_interval = 5; //in ms
+  worker_settings.worker_count = 1;
+  worker_settings.worker_queue_hard_limit = 4;
+  worker_settings.worker_queue_soft_limit = 2;
   worker_settings.can_drop = 0;
 
   cuvis_exporter_create_cube(&cube_exporter, general_settings, cube_settings);
 
+  printf("initialize processing pipeline worker...\n");
   CUVIS_WORKER worker;
   cuvis_worker_create(&worker, worker_settings);
 
@@ -104,8 +104,7 @@ int main(int argc, char* argv[])
   procArgs.processing_mode = Cube_Raw;
 
   printf("waiting for camera to become online...\n");
-  fflush(stdout);
-  for (;;)
+  while (1)
   {
     CUVIS_HARDWARE_STATE state;
     cuvis_acq_cont_get_state(acqCont, &state);
@@ -113,13 +112,11 @@ int main(int argc, char* argv[])
     if (state == hardware_state_online)
     {
       printf("\ncamera online\n");
-      fflush(stdout);
       break;
     }
     if (state == hardware_state_partially_online)
     {
       printf("\ncamera partially online\n");
-      fflush(stdout);
       break;
     }
 
@@ -132,8 +129,7 @@ int main(int argc, char* argv[])
     fflush(stdout);
   }
 
-  printf("component details:\n");
-  fflush(stdout);
+  printf("camera components details:\n");
   CUVIS_INT compCount;
   CUVIS_CHECK(cuvis_acq_cont_get_component_count(acqCont, &compCount));
   for (unsigned compIdx = 0; compIdx < compCount; compIdx++)
@@ -144,80 +140,40 @@ int main(int argc, char* argv[])
     CUVIS_CHECK(cuvis_acq_cont_get_component_info(acqCont, compIdx, &cinfo));
     CUVIS_CHECK(cuvis_comp_online_get(acqCont, compIdx, &online));
     printf(" - component '%s' is ", cinfo.displayname);
-    fflush(stdout);
     if (online != 0)
     {
       printf("online\n");
-      fflush(stdout);
     }
     else
     {
       printf("offline\n");
-      fflush(stdout);
     }
     printf(" -- info:        %s\n", cinfo.sensorinfo);
     printf(" -- use:         %s\n", cinfo.userfield);
     printf(" -- pixelformat: %s\n", cinfo.pixelformat);
-    fflush(stdout);
   }
 
-  printf("initializing hardware...\n");
-  fflush(stdout);
-  cuvis_acq_cont_integration_time_set(acqCont, exposure_ms);
-  cuvis_acq_cont_operation_mode_set(acqCont, OperationMode_Software);
-  
+  printf("configuring camera components...\n");
+  // Configure exposure / integration time and software trigger
+  CUVIS_CHECK(cuvis_acq_cont_integration_time_set(acqCont, exposure_ms));
+  CUVIS_CHECK(cuvis_acq_cont_operation_mode_set(acqCont, OperationMode_Software));
+
+  // Assign contexts to worker
+  CUVIS_CHECK(cuvis_worker_set_acq_cont(worker, acqCont));
+  CUVIS_CHECK(cuvis_worker_set_proc_cont(worker, procCont));
+  CUVIS_CHECK(cuvis_worker_set_exporter(worker, cube_exporter));
 
   printf("start recording now\n");
-  fflush(stdout);
 
   for (int k = 0; k < nrImages; k++)
   {
-    CUVIS_MESU mesu;
-    CUVIS_VIEW view;
+    printf("trigger image nr. %d/%d\n", k + 1, nrImages);
+    CUVIS_CHECK(cuvis_acq_cont_capture_async(acqCont, NULL));
 
-    printf("trigger image nr. %d/10 (software) \n", k + 1);
-    fflush(stdout);
-    cuvis_worker_set_acq_cont(worker, acqCont);
-    cuvis_worker_set_proc_cont(worker, procCont);
-    cuvis_worker_set_exporter(worker, cube_exporter);
-
-    CUVIS_INT hasNext;
-    cuvis_worker_has_next_result(worker, &hasNext);
-
-    if (hasNext)
-    {
-      cuvis_worker_get_next_result(worker, &mesu, &view, -1);
-      printf("recorded mesu (id %d)\n", k);
-      printf("process mesu  (id %d)\n", k);
-      fflush(stdout);
-      CUVIS_CHECK(cuvis_proc_cont_set_args(procCont, procArgs));
-      CUVIS_CHECK(cuvis_proc_cont_apply(procCont, mesu));
-
-      printf("save to cu3s   (id %d) \n", k);
-      fflush(stdout);
-      //the cube exporter exports the measurement and sets the path in the measurement's meta-data
-      cuvis_exporter_apply(cube_exporter, mesu);
-
-      CUVIS_MESU_METADATA mesu_data;
-      CUVIS_CHECK(cuvis_measurement_get_metadata(mesu, &mesu_data));
-
-      printf("location: %s/%s.cu3s\n", mesu_data.path, mesu_data.name);
-
-      printf("release mesu  (id %d)\n", k);
-      fflush(stdout);
-      cuvis_measurement_free(&mesu);
-    }
-    else
-    {
-#ifdef WIN32
-      Sleep(500);
-#else
-      usleep(50000);
-#endif
-    }
+    printf("waiting for processing...\n");
+    CUVIS_CHECK(cuvis_worker_get_next_result(worker, NULL, NULL, exposure_ms + 2000));
   }
   printf("done. cleaning up...\n");
-  fflush(stdout);
 
   cuvis_exporter_free(&cube_exporter);
   cuvis_proc_cont_free(&procCont);
@@ -226,5 +182,4 @@ int main(int argc, char* argv[])
   cuvis_worker_free(&worker);
 
   printf("finished.\n");
-  fflush(stdout);
 }

--- a/06_recordVideo/main.c
+++ b/06_recordVideo/main.c
@@ -106,6 +106,9 @@ int main(int argc, char* argv[])
   cube_settings.fps = fps;
   cube_settings.operation_mode = OperationMode_Internal;
   cube_settings.allow_info_file = 1;
+  cube_settings.hard_limit = 4;
+  cube_settings.soft_limit = 2;
+
 
   CUVIS_CHECK(cuvis_exporter_create_cube(
       &cube_exporter, general_settings, cube_settings));
@@ -183,7 +186,7 @@ int main(int argc, char* argv[])
   printf("initializing hardware...\n");
   fflush(stdout);
 
-  CUVIS_CHECK(cuvis_acq_cont_integration_time_set(acqCont, 100));
+  CUVIS_CHECK(cuvis_acq_cont_integration_time_set(acqCont, exposure_ms));
   CUVIS_CHECK(
       cuvis_acq_cont_operation_mode_set(acqCont, OperationMode_Internal));
   CUVIS_CHECK(cuvis_acq_cont_fps_set(acqCont, fps));


### PR DESCRIPTION
- Fix use of worker in example 5
- Fix exposure setting in example 6
- Set necessary parameters for cube exporter queue size