### PR TITLE
Adding missing include + fix broken params

### DIFF
--- a/Example_1_Take_Snapshot/main.c
+++ b/Example_1_Take_Snapshot/main.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 
 #ifdef WIN32

--- a/Example_1_Take_Snapshot/main.c
+++ b/Example_1_Take_Snapshot/main.c
@@ -154,9 +154,8 @@ int main(int argc, char* argv[])
   printf("initialize measurement exporter...\n");
   CUVIS_EXPORTER cube_exporter;
 
-  // Export settings: General processing of measurements
-  CUVIS_EXPORT_GENERAL_SETTINGS general_settings = {
-      "", // initializer list only takes const char*, leave empty and modify afterwards.
+  // pan sharpening settings
+  CUVIS_PANSHARPENING_SETTINGS ps_settings = {
       "all",
       1,
       0.0,
@@ -164,6 +163,15 @@ int main(int argc, char* argv[])
       pan_sharpening_algorithm_Noop,
       0,
       0};
+
+  // Export settings: General processing of measurements
+  CUVIS_EXPORT_GENERAL_SETTINGS general_settings = {
+      "", // initializer list only takes const char*, leave empty and modify afterwards.
+      0,
+      0,
+      ps_settings};
+
+
 
   strcpy(general_settings.export_dir, recDir);
 

--- a/Example_3_Reprocess/main.c
+++ b/Example_3_Reprocess/main.c
@@ -147,8 +147,8 @@ int main(int argc, char* argv[])
   args.allow_recalib = 0;
   CUVIS_CHECK(cuvis_proc_cont_is_capable(procCont, mesu, args, &is_capable));
 
-  CUVIS_EXPORT_GENERAL_SETTINGS general_settings = {
-      "", // initializer list only takes const char*, leave empty and modify afterwards.
+  // pan sharpening settings
+  CUVIS_PANSHARPENING_SETTINGS ps_settings = {
       "all",
       1,
       0.0,
@@ -156,6 +156,13 @@ int main(int argc, char* argv[])
       pan_sharpening_algorithm_Noop,
       0,
       0};
+
+  // Export settings: General processing of measurements
+  CUVIS_EXPORT_GENERAL_SETTINGS general_settings = {
+      "", // initializer list only takes const char*, leave empty and modify afterwards.
+      0,
+      0,
+      ps_settings};
 
   CUVIS_EXPORT_CUBE_SETTINGS cube_settings;
   cube_settings.merge_mode = session_merge_mode_Default;

--- a/Example_3_Reprocess/main.c
+++ b/Example_3_Reprocess/main.c
@@ -1,6 +1,7 @@
 #include "cuvis.h"
 
 #include <stdio.h>
+#include <string.h>
 
 int main(int argc, char* argv[])
 {

--- a/Example_4_Exporters/main.c
+++ b/Example_4_Exporters/main.c
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 
 int main(int argc, char* argv[])

--- a/Example_5_Record_Video/main.c
+++ b/Example_5_Record_Video/main.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 
 #ifdef WIN32

--- a/Example_5_Record_Video/main.c
+++ b/Example_5_Record_Video/main.c
@@ -164,8 +164,8 @@ int main(int argc, char* argv[])
   fflush(stdout);
   CUVIS_EXPORTER cube_exporter;
 
-  CUVIS_EXPORT_GENERAL_SETTINGS general_settings = {
-      "", // initializer list only takes const char*, leave empty and modify afterwards.
+  // pan sharpening settings
+  CUVIS_PANSHARPENING_SETTINGS ps_settings = {
       "all",
       1,
       0.0,
@@ -173,6 +173,14 @@ int main(int argc, char* argv[])
       pan_sharpening_algorithm_Noop,
       0,
       0};
+
+  // Export settings: General processing of measurements
+  CUVIS_EXPORT_GENERAL_SETTINGS general_settings = {
+      "", // initializer list only takes const char*, leave empty and modify afterwards.
+      0,
+      0,
+      ps_settings};
+      
   strcpy(general_settings.export_dir, recDir);
 
   CUVIS_EXPORT_CUBE_SETTINGS cube_settings;

--- a/Example_6_Record_Video_From_SessionFile/main.c
+++ b/Example_6_Record_Video_From_SessionFile/main.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef WIN32
   #include <Windows.h>
@@ -127,7 +128,7 @@ int main(int argc, char* argv[])
       0,
       0,
       ps_settings};
-      
+
   strcpy(general_settings.export_dir, recDir);
 
   CUVIS_EXPORT_CUBE_SETTINGS cube_settings;

--- a/Example_6_Record_Video_From_SessionFile/main.c
+++ b/Example_6_Record_Video_From_SessionFile/main.c
@@ -111,8 +111,8 @@ int main(int argc, char* argv[])
 
   CUVIS_EXPORTER cube_exporter;
 
-  CUVIS_EXPORT_GENERAL_SETTINGS general_settings = {
-      "", // initializer list only takes const char*, leave empty and modify afterwards.
+  // pan sharpening settings
+  CUVIS_PANSHARPENING_SETTINGS ps_settings = {
       "all",
       1,
       0.0,
@@ -120,6 +120,14 @@ int main(int argc, char* argv[])
       pan_sharpening_algorithm_Noop,
       0,
       0};
+
+  // Export settings: General processing of measurements
+  CUVIS_EXPORT_GENERAL_SETTINGS general_settings = {
+      "", // initializer list only takes const char*, leave empty and modify afterwards.
+      0,
+      0,
+      ps_settings};
+      
   strcpy(general_settings.export_dir, recDir);
 
   CUVIS_EXPORT_CUBE_SETTINGS cube_settings;

--- a/Example_7_Change_Distance/main.c
+++ b/Example_7_Change_Distance/main.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 int main(int argc, char* argv[])
 {

--- a/Example_7_Change_Distance/main.c
+++ b/Example_7_Change_Distance/main.c
@@ -105,8 +105,8 @@ int main(int argc, char* argv[])
   fflush(stdout);
   CUVIS_EXPORTER cube_exporter;
 
-  CUVIS_EXPORT_GENERAL_SETTINGS general_settings = {
-      "", // initializer list only takes const char*, leave empty and modify afterwards.
+  // pan sharpening settings
+  CUVIS_PANSHARPENING_SETTINGS ps_settings = {
       "all",
       1,
       0.0,
@@ -114,6 +114,13 @@ int main(int argc, char* argv[])
       pan_sharpening_algorithm_Noop,
       0,
       0};
+
+  // Export settings: General processing of measurements
+  CUVIS_EXPORT_GENERAL_SETTINGS general_settings = {
+      "", // initializer list only takes const char*, leave empty and modify afterwards.
+      0,
+      0,
+      ps_settings};
 
   strcpy(general_settings.export_dir, exportDir);
 


### PR DESCRIPTION
The missing string.h include causes the examples to fail compiling on Ubuntu 26.04
Also the restructuring of the export arguments was not present in every example